### PR TITLE
Add Created Field to Finding Data Model and Update Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,12 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
-    compile group: 'org.springframework', name: 'spring-web', version: '5.2.12.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-web', version: '5.3.9'
 
-    compile 'com.fasterxml.jackson.core:jackson-core:2.12.0'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.12.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.4'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.4'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4'
 }
 
 publishing {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/Finding.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/Finding.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.securecodebox.persistence.defectdojo.exceptions.DefectDojoPersistenceException;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -91,6 +92,9 @@ public class Finding extends DefectDojoModel {
   @NonNull
   @Builder.Default
   List<Long> endpoints = new LinkedList<>();
+
+  @JsonProperty("created")
+  LocalDateTime createdAt;
 
   @JsonProperty("numerical_severity")
   public String getNumericalSeverity() {


### PR DESCRIPTION
Updated the prod dependencies to their latest version, fortunately didn't seem to need code changes.
I needed to add an additional jackson lib (`com.fasterxml.jackson.datatype:jackson-datatype-jsr310`) to properly handle the modern java time formats.

We'll need the created field of the findings to properly support our `parsed_at` field in the findings in the secureCodeBox v3 data model, so I've added that.