### PR TITLE
Use http proxy vars without authentication

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/ImportScanService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/ImportScanService.java
@@ -68,22 +68,24 @@ public class ImportScanService {
     }
 
     protected RestTemplate getRestTemplate() {
-        if (System.getProperty("http.proxyUser") != null && System.getProperty("http.proxyPassword") != null) {
-            // Configuring Proxy Authentication explicitly as it isn't done by default for spring rest templates :(
-            CredentialsProvider credsProvider = new BasicCredentialsProvider();
-            credsProvider.setCredentials(
-                    new AuthScope(System.getProperty("http.proxyHost"), Integer.parseInt(System.getProperty("http.proxyPort"))),
-                    new UsernamePasswordCredentials(System.getProperty("http.proxyUser"), System.getProperty("http.proxyPassword"))
-            );
+        if (System.getProperty("http.proxyHost") != null && System.getProperty("http.proxyPort") != null) {
             HttpClientBuilder clientBuilder = HttpClientBuilder.create();
-
             clientBuilder.useSystemProperties();
             clientBuilder.setProxy(new HttpHost(System.getProperty("http.proxyHost"), Integer.parseInt(System.getProperty("http.proxyPort"))));
-            clientBuilder.setDefaultCredentialsProvider(credsProvider);
-            clientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+
+            if (System.getProperty("http.proxyUser") != null && System.getProperty("http.proxyPassword") != null) {
+                // Configuring Proxy Authentication explicitly as it isn't done by default for spring rest templates :(
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(
+                        new AuthScope(System.getProperty("http.proxyHost"), Integer.parseInt(System.getProperty("http.proxyPort"))),
+                        new UsernamePasswordCredentials(System.getProperty("http.proxyUser"), System.getProperty("http.proxyPassword"))
+                );
+
+                clientBuilder.setDefaultCredentialsProvider(credsProvider);
+                clientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+            }
 
             CloseableHttpClient client = clientBuilder.build();
-
             HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
             factory.setHttpClient(client);
             return new RestTemplate(factory);


### PR DESCRIPTION
In addtion to to use a proxy with username/password, a proxy without username/password might be used.
For that case, it mst be initalized.
See for example https://stackoverflow.com/questions/5165126/without-changing-code-how-to-force-httpclient-to-use-proxy-by-environment-varia

By using the current implementation (0.0.24) with http.proxyHost and http.proxyPort I get a "connection timeout".
By using the current implementation (0.0.24) with http.proxyHost, http.proxyUser (value: p), http.proxyPassword (value: p) and http.proxyPort I get  a  "connection reset". I am not sure if it is because of wrong credentails, but it is not correct to set all variables.

By using the current implementation (0.0.24) with http.proxyHost, http.proxyUser (empty), http.proxyPassword (empty) and http.proxyPort it works.