### PR TITLE
feat: add RiskAcceptance and DojoGroup with more details

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/DojoGroup.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/DojoGroup.java
@@ -32,6 +32,9 @@ public class DojoGroup extends DefectDojoModel {
         if (queryParams.containsKey("id") && queryParams.get("id").equals(this.id)) {
             return true;
         }
+        if (queryParams.containsKey("name") && queryParams.get("name").equals(this.name)) {
+            return true;
+        }
         return false;
     }
 }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/DojoGroupMember.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/DojoGroupMember.java
@@ -30,6 +30,9 @@ public class DojoGroupMember extends DefectDojoModel {
         if (queryParams.containsKey("id") && queryParams.get("id").equals(this.id)) {
             return true;
         }
+        if (queryParams.containsKey("group") && queryParams.get("group").equals(this.group)) {
+            return true;
+        }
         return false;
     }
 }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/ProductGroup.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/ProductGroup.java
@@ -33,12 +33,6 @@ public class ProductGroup extends DefectDojoModel {
         if (queryParams.containsKey("product") && queryParams.get("product").equals(this.product) && queryParams.containsKey("group") && queryParams.get("group").equals(this.group)) {
             return true;
         }
-        if (queryParams.containsKey("product") && queryParams.get("product").equals(this.product) && !queryParams.containsKey("group")) {
-            return true;
-        }
-        if (queryParams.containsKey("group") && queryParams.get("group").equals(this.group) && !queryParams.containsKey("product")) {
-            return true;
-        }
         return false;
     }
 }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/ProductGroup.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/ProductGroup.java
@@ -30,6 +30,15 @@ public class ProductGroup extends DefectDojoModel {
         if (queryParams.containsKey("id") && queryParams.get("id").equals(this.id)) {
             return true;
         }
+        if (queryParams.containsKey("product") && queryParams.get("product").equals(this.product) && queryParams.containsKey("group") && queryParams.get("group").equals(this.group)) {
+            return true;
+        }
+        if (queryParams.containsKey("product") && queryParams.get("product").equals(this.product) && !queryParams.containsKey("group")) {
+            return true;
+        }
+        if (queryParams.containsKey("group") && queryParams.get("group").equals(this.group) && !queryParams.containsKey("product")) {
+            return true;
+        }
         return false;
     }
 }


### PR DESCRIPTION
In case I want to search for a combination (e.g. product AND group), do I need it as complicated as in https://github.com/secureCodeBox/defectdojo-client-java/pull/17/files#diff-7f90db6846c1c15d797f96d5347f8c7b6fb8435cdf3c6a348a970c2d8e9adb04R33 ?