### PR TITLE
fix attribute expiration_date_warned

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/models/RiskAcceptance.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/models/RiskAcceptance.java
@@ -55,9 +55,6 @@ public class RiskAcceptance extends DefectDojoModel {
   String expiration_date;
 
   @JsonProperty
-  LocalDateTime expiration_date_warned;
-
-  @JsonProperty
   Boolean expiration_date_handled;
 
   @JsonProperty("created")


### PR DESCRIPTION
fix:

```
Caught: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `java.lang.Boolean` from String "2022-06-10T00:00:00.726766Z": only "true" or "false" recognized
 at [Source: (StringReader); line: 1, column: 374212] (through reference chain: io.securecodebox.persistence.defectdojo.models.DefectDojoResponse["results"]->java.util.ArrayList[93]->io.securecodebox.persistence.defectdojo.models.Finding["accepted_risks"]->java.util.ArrayList[0]->io.securecodebox.persistence.defectdojo.models.R
iskAcceptance["expiration_date_handled"])
```