### PR TITLE
Fix time deserialization

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Finding.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Finding.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.securecodebox.persistence.defectdojo.exception.PersistenceException;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -101,10 +101,10 @@ public class Finding extends BaseModel {
     List<Long> endpoints = new LinkedList<>();
 
     @JsonProperty("created")
-    LocalDateTime createdAt;
+    OffsetDateTime createdAt;
 
     @JsonProperty("mitigated")
-    LocalDateTime mitigatedAt;
+    OffsetDateTime mitigatedAt;
 
     @JsonProperty("accepted_risks")
     List<RiskAcceptance> acceptedRisks;

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/RiskAcceptance.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/RiskAcceptance.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 @Data
@@ -40,19 +40,19 @@ public class RiskAcceptance extends BaseModel {
   String acceptedBy;
 
   @JsonProperty("expiration_date")
-  LocalDateTime expirationDate;
+  OffsetDateTime expirationDate;
 
   @JsonProperty("expiration_date_warned")
-  LocalDateTime expirationDateWarned;
+  OffsetDateTime expirationDateWarned;
 
   @JsonProperty("expiration_date_handled")
-  LocalDateTime expirationDateHandled;
+  OffsetDateTime expirationDateHandled;
 
   @JsonProperty("created")
-  LocalDateTime createdAt;
+  OffsetDateTime createdAt;
 
   @JsonProperty("updated")
-  LocalDateTime updatedAt;
+  OffsetDateTime updatedAt;
 
   @JsonProperty
   Long owner;

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /*
  * https://defectdojo.security.iteratec.dev/api/v2/oa3/swagger-ui/#operations-tag-import-scan
  */
-public class DefaultImportScanService implements ImportScanService {
+class DefaultImportScanService implements ImportScanService {
     private static final List<HttpMessageConverter<?>> HTTP_MESSAGE_CONVERTERS = List.of(
         new FormHttpMessageConverter(),
         new ResourceHttpMessageConverter(),
@@ -56,7 +56,7 @@ public class DefaultImportScanService implements ImportScanService {
      *
      * @param config not {@code null}
      */
-    public DefaultImportScanService(final @NonNull Config config) {
+    DefaultImportScanService(final @NonNull Config config) {
         super();
         this.defectDojoUrl = config.getUrl();
         this.defectDojoApiKey = config.getApiKey();

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /*
  * https://defectdojo.security.iteratec.dev/api/v2/oa3/swagger-ui/#operations-tag-import-scan
  */
-class DefaultImportScanService implements ImportScanService {
+public class DefaultImportScanService implements ImportScanService {
     private static final List<HttpMessageConverter<?>> HTTP_MESSAGE_CONVERTERS = List.of(
         new FormHttpMessageConverter(),
         new ResourceHttpMessageConverter(),
@@ -56,7 +56,7 @@ class DefaultImportScanService implements ImportScanService {
      *
      * @param config not {@code null}
      */
-    DefaultImportScanService(final @NonNull Config config) {
+    public DefaultImportScanService(final @NonNull Config config) {
         super();
         this.defectDojoUrl = config.getUrl();
         this.defectDojoApiKey = config.getApiKey();


### PR DESCRIPTION
Closes [#29](https://github.com/secureCodeBox/defectdojo-client-java/issues/29)

When setting the `DD_TIME_ZONE` parameter in DefectDojo, times are served with the particular time zone (e.g. "2023-04-14T12:00:00.796635+08:00" instead of "2023-04-14T12:00:00.796635"). However, the `LocalDateTime` class does not support time zones and is therefore unsuitable. Replacing it with `OffsetDateTime` solves this issue.