### PR TITLE
Improve sonatype publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,10 +111,12 @@ jacocoTestReport {
 
 // https://docs.gradle.org/current/userguide/signing_plugin.html
 signing {
-    String signingKey = System.getenv("SIGNING_KEY")
-    String signingPassword = System.getenv("SIGNING_PASSWORD")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.jar
+    if (!version.endsWith('SNAPSHOT')) {  // only sign non-snapshot versions
+        String signingKey = System.getenv("SIGNING_KEY")
+        String signingPassword = System.getenv("SIGNING_PASSWORD")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.jar
+    }
 }
 
 // https://github.com/johnrengelman/shadow/issues/718

--- a/build.gradle
+++ b/build.gradle
@@ -44,21 +44,6 @@ dependencies {
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.0.2'
 }
 
-repositories {
-    repositories {
-        maven {
-            // change URLs to point to your repos, e.g. http://my.org/repo
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials{
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-            }
-        }
-    }
-}
-
 publishing {
     publications.register("jar", MavenPublication) {
         from components.java
@@ -93,6 +78,17 @@ publishing {
                 connection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
                 developerConnection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
                 url = 'https://github.com/secureCodeBox/defectdojo-client-java'
+            }
+        }
+    }
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -44,56 +44,55 @@ dependencies {
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.0.2'
 }
 
-publishing {
-    publications {
-        register("jar", MavenPublication) {
-            from(components["java"])
-            pom {
-                name = 'DefectDojo Client Java'
-                description = 'Java Client to interact with the DefectDojo API.'
-                url = 'https://github.com/secureCodeBox/defectdojo-client-java'
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'jannik.hollenbach'
-                        name = 'Jannik Hollenbach'
-                        email = 'jannik.hollenbach@iteratec.com'
-                    }
-                    developer {
-                        id = 'robert.seedorff'
-                        name = 'Robert Seedorff'
-                        email = 'robert.seedorff@iteratec.com'
-                    }
-                    developer {
-                        id = 'johannes.zahn'
-                        name = 'Johannes Zahn'
-                        email = 'johannes.zahn@iteratec.com'
-                    }
-                }
-                scm {
-                    connection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
-                    developerConnection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
-                    url = 'https://github.com/secureCodeBox/defectdojo-client-java'
-                }
+repositories {
+    repositories {
+        maven {
+            // change URLs to point to your repos, e.g. http://my.org/repo
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials{
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
             }
         }
     }
-    repositories {
-        repositories {
-            maven {
-                // change URLs to point to your repos, e.g. http://my.org/repo
-                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-                credentials{
-                    username = System.getenv("MAVEN_USERNAME")
-                    password = System.getenv("MAVEN_PASSWORD")
+}
+
+publishing {
+    publications.register("jar", MavenPublication) {
+        from components.java
+        pom {
+            name = 'DefectDojo Client Java'
+            description = 'Java Client to interact with the DefectDojo API.'
+            url = 'https://github.com/secureCodeBox/defectdojo-client-java'
+            licenses {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                 }
+            }
+            developers {
+                developer {
+                    id = 'jannik.hollenbach'
+                    name = 'Jannik Hollenbach'
+                    email = 'jannik.hollenbach@iteratec.com'
+                }
+                developer {
+                    id = 'robert.seedorff'
+                    name = 'Robert Seedorff'
+                    email = 'robert.seedorff@iteratec.com'
+                }
+                developer {
+                    id = 'johannes.zahn'
+                    name = 'Johannes Zahn'
+                    email = 'johannes.zahn@iteratec.com'
+                }
+            }
+            scm {
+                connection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
+                developerConnection = 'scm:git@github.com:secureCodeBox/defectdojo-client-java.git'
+                url = 'https://github.com/secureCodeBox/defectdojo-client-java'
             }
         }
     }


### PR DESCRIPTION
- Do not sign artifacts in publishing when version is not a snapshot
- Using a [workaround](https://youtrack.jetbrains.com/issue/IDEA-162281/False-warning-version-cannot-be-applied-to-java.lang.String#focus=Comments-27-7054237.0-0) to bypass a false-positive IntelliJ warning in `build.gradle`