### PR TITLE
Enable Dependabot for Workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gradle" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gradle"
+    directory: "/"
     schedule:
       interval: "weekly"
+  -   package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+  -   package-ecosystem: "github-actions"
+      directory: "/.github/workflows"
+      schedule:
+          interval: "weekly"


### PR DESCRIPTION
We want to be notified if

- used GitHub actions and
- used baes images in the workflow

are outdated.

We are not sure if it will work. This is a first try.

The docker ecosystem is configured globaly because we may use containers outside workflows and we hope that Dependabot searches recursive. We are also not sure if Dependabot recognizes the image tag in the workflow YAML as Docker dependency.