### PR TITLE
Add bot token already in checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.SCB_BOT_USER_TOKEN }} # here because https://www.paulmowat.co.uk/blog/resolve-github-action-gh006-protected-branch-update-failed
           fetch-depth: 0 # required by previous_tag
 
       - name: Set up JDK 17


### PR DESCRIPTION
As mentioned in [this article](https://www.paulmowat.co.uk/blog/resolve-github-action-gh006-protected-branch-update-failed), the bot token must be already included in the checkout step of the job (which performs a push on the main branch)