### PR TITLE
Revert "Add bot token already in checkout"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SCB_BOT_USER_TOKEN }} # here because https://www.paulmowat.co.uk/blog/resolve-github-action-gh006-protected-branch-update-failed
           fetch-depth: 0 # required by previous_tag
 
       - name: Set up JDK 17


### PR DESCRIPTION
Adding the `token` attribute in the checkout step causes the following unknown error: `Error: fatal: could not read Username for 'https://github.com/': terminal prompts disabled`. For now, we revert the changes proposed in the mentioned blog article.