### PR TITLE
Remove explicit dependency infos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,16 +91,6 @@ jobs:
           MVN_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           echo "MVN_VERSION=$MVN_VERSION" >> $GITHUB_OUTPUT
 
-        # Replaced all version occurrences in README.md in the form: <version>1.0.0</version> or version: '1.0.0'
-        # A version can be 1.0.0, 1.0.0-SNAPSHOT, or 1.0.0-beta4
-      - name: "Change README"
-        run: |
-          sed -i -e "s@\(<version>\)\([0-9].[0-9].[0-9]\(-[A-z0-9]*\)*\)\(</version>\)@\1${{ steps.extract-version.outputs.MVN_VERSION }}\4@g" README.md
-          sed -i -e "s@\(version: '\)\([0-9].[0-9].[0-9]\(-[A-z0-9]*\)*\)\('\)@\1${{ steps.extract-version.outputs.MVN_VERSION }}\4@g" README.md
-          git add README.md
-          git commit -sS -m "Update version in README" || true
-          git push
-
       # Required for creation of GitHub release
       - name: "Get previous tag"
         id: previous_tag

--- a/README.md
+++ b/README.md
@@ -10,23 +10,7 @@ Java Client to interact with the DefectDojo API.
 
 ## Dependency Information
 
-You can find the latest version on [Maven Central](https://central.sonatype.com/artifact/io.securecodebox/defectdojo-client/).
-
-### Maven
-
-```xml
-<dependency>
-    <groupId>io.securecodebox</groupId>
-    <artifactId>defectdojo-client</artifactId>
-    <version>1.0.1</version>
-</dependency>
-```
-
-### Gradle
-
-```groovy
-implementation group: 'io.securecodebox', name: 'defectdojo-client', version: '1.0.1'
-```
+You can find the latest version and dependency infos on [Maven Central](https://central.sonatype.com/artifact/io.securecodebox/defectdojo-client/).
 
 ## Development
 


### PR DESCRIPTION
The information can be foundon Maven central, and so we need not to update the README.md on every release.