### PR TITLE
Only run maven publishing on secureCodeBox/defectdojo-client-java repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   publish-release:
     runs-on: ubuntu-22.04
+    if: github.repository == 'secureCodeBox/defectdojo-client-java'
     permissions:
       contents: write # needed for release creation
     steps:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   publish-snapshot:
     runs-on: ubuntu-22.04
+    if: github.repository == 'secureCodeBox/defectdojo-client-java'
     steps:
 
       - name: Checkout repository


### PR DESCRIPTION
Only run the `publish-release` and `publish-snapshot` jobs in our main secureCodeBox/defectdojo-client-java repo. This prevents errors in forks