### PR TITLE
Use latest 5.x Spring dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <!-- Dependency versions: -->
         <com.fasterxml.jackson.version>2.16.1</com.fasterxml.jackson.version>
-        <org.springframework.version>5.3.28</org.springframework.version>
+        <org.springframework.version>5.3.29</org.springframework.version>
         <org.mockito.version>5.9.0</org.mockito.version>
     </properties>
 


### PR DESCRIPTION
There was a high vuln in the 5.3.28 and [6.x has breaking changes](https://github.com/secureCodeBox/defectdojo-client-java/issues/69).