### PR TITLE
Improve Error Message on Failed Attachment of Finding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.securecodebox</groupId>
     <artifactId>defectdojo-client</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>DefectDojo Client Java</name>
     <description>
@@ -122,6 +122,12 @@
             <version>${com.fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>2.0.11</version>
+        </dependency>
+
+      <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.30</version>

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
@@ -11,6 +11,7 @@ import io.securecodebox.persistence.defectdojo.http.ProxyConfig;
 import io.securecodebox.persistence.defectdojo.model.ScanFile;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -40,6 +41,7 @@ import java.util.Map;
 /*
  * https://defectdojo.security.iteratec.dev/api/v2/oa3/swagger-ui/#operations-tag-import-scan
  */
+@Slf4j
 class DefaultImportScanService implements ImportScanService {
     private static final List<HttpMessageConverter<?>> HTTP_MESSAGE_CONVERTERS = List.of(
             new FormHttpMessageConverter(),
@@ -123,7 +125,8 @@ class DefaultImportScanService implements ImportScanService {
             final var payload = new HttpEntity<MultiValueMap<String, Object>>(body, headers);
             return exchangeRequest(endpoint, payload);
         } catch (HttpClientErrorException e) {
-            throw new PersistenceException("Failed to attach findings to engagement.");
+            log.error("Exception while attaching findings to engagement: {}", e.getMessage());
+            throw new PersistenceException("Failed to attach findings to engagement.", e);
         }
     }
 


### PR DESCRIPTION
The original code does not provide the causing error, which makes it dificult to debug the problem.

- Add first adding loggign capabilities via SLF4J.
- Log the failed attempt of attaching a finding as eror w/ original exception message.
- Pass the causing exception to the exception we rethrow to preserve the full stack trace.

Relates to https://github.com/secureCodeBox/secureCodeBox/issues/2271