### PR TITLE
#127 Improve Error Handling for Failed DefectDojo API Requests

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/DefaultImportScanService.java
@@ -31,7 +31,7 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
@@ -124,7 +124,7 @@ class DefaultImportScanService implements ImportScanService {
 
       final var payload = new HttpEntity<MultiValueMap<String, Object>>(body, headers);
       return exchangeRequest(endpoint, payload);
-    } catch (HttpClientErrorException e) {
+    } catch (RestClientException e) {
       log.error("Exception while attaching findings to engagement: {}", e.getMessage());
       throw new PersistenceException("Failed to attach findings to engagement.", e);
     }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/GenericDefectDojoService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/GenericDefectDojoService.java
@@ -75,6 +75,7 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
 
     final var url = this.config.getUrl() + API_PREFIX + this.getUrlPath() + "/" + id;
     log.debug("Requesting URL: {}", url);
+
     try {
       ResponseEntity<T> response = restTemplate.exchange(
         url,
@@ -85,8 +86,8 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
 
       return response.getBody();
     } catch (RestClientException e) {
-      log.error("Exception while getting data: {}", e.getMessage());
-      throw new PersistenceException("Failed to get data.", e);
+      log.error("Exception while doing a GET request to DefectDojo API: {}", e.getMessage());
+      throw new PersistenceException("Failed to do a GET to DefectDojo API!", e);
     }
   }
 
@@ -140,8 +141,17 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
     var restTemplate = this.getRestTemplate();
     HttpEntity<T> payload = new HttpEntity<>(object, getDefectDojoAuthorizationHeaders());
 
-    ResponseEntity<T> response = restTemplate.exchange(this.config.getUrl() + API_PREFIX + getUrlPath() + "/", HttpMethod.POST, payload, getModelClass());
-    return response.getBody();
+    try {
+      ResponseEntity<T> response = restTemplate.exchange(
+        this.config.getUrl() + API_PREFIX + getUrlPath() + "/",
+        HttpMethod.POST,
+        payload,
+        getModelClass());
+      return response.getBody();
+    } catch (RestClientException e) {
+      log.error("Exception while doing a POST request to DefectDojo API: {}", e.getMessage());
+      throw new PersistenceException("Failed to do a POST to DefectDojo API!", e);
+    }
   }
 
   @Override
@@ -149,7 +159,16 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
     var restTemplate = this.getRestTemplate();
     HttpEntity<String> payload = new HttpEntity<>(getDefectDojoAuthorizationHeaders());
 
-    restTemplate.exchange(this.config.getUrl() + API_PREFIX + getUrlPath() + "/" + id + "/", HttpMethod.DELETE, payload, String.class);
+    try {
+      restTemplate.exchange(
+        this.config.getUrl() + API_PREFIX + getUrlPath() + "/" + id + "/",
+        HttpMethod.DELETE,
+        payload,
+        String.class);
+    } catch (RestClientException e) {
+      log.error("Exception while doing a DELETE request to DefectDojo API: {}", e.getMessage());
+      throw new PersistenceException("Failed to do a DELETE to DefectDojo API!", e);
+    }
   }
 
   @Override
@@ -157,10 +176,18 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
     var restTemplate = this.getRestTemplate();
     HttpEntity<T> payload = new HttpEntity<>(object, getDefectDojoAuthorizationHeaders());
 
-    ResponseEntity<T> response = restTemplate.exchange(this.config.getUrl() + API_PREFIX + getUrlPath() + "/" + id + "/", HttpMethod.PUT, payload, getModelClass());
-    return response.getBody();
+    try {
+      ResponseEntity<T> response = restTemplate.exchange(this.config.getUrl() + API_PREFIX + getUrlPath() + "/" + id + "/",
+        HttpMethod.PUT,
+        payload,
+        getModelClass());
+      return response.getBody();
+    } catch (RestClientException e) {
+      log.error("Exception while doing a PUT request to DefectDojo API: {}", e.getMessage());
+      throw new PersistenceException("Failed to do a PUT to DefectDojo API!", e);
+    }
   }
-  
+
   /**
    * Get the URL path for the REST endpoint relative to {@link #API_PREFIX}
    *
@@ -222,13 +249,18 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
     log.debug("Requesting URL: {}", url);
     var uriBuilder = UriComponentsBuilder.fromUri(url).queryParams(multiValueMap);
 
-    ResponseEntity<String> responseString = restTemplate.exchange(
-      uriBuilder.build(mutableQueryParams),
-      HttpMethod.GET,
-      payload,
-      String.class
-    );
+    try {
+      ResponseEntity<String> responseString = restTemplate.exchange(
+        uriBuilder.build(mutableQueryParams),
+        HttpMethod.GET,
+        payload,
+        String.class
+      );
 
-    return deserializeList(responseString.getBody());
+      return deserializeList(responseString.getBody());
+    } catch (RestClientException e) {
+      log.error("Exception while doing a GET request to DefectDojo API: {}", e.getMessage());
+      throw new PersistenceException("Failed to do a GET to DefectDojo API!", e);
+    }
   }
 }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/GenericDefectDojoService.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/GenericDefectDojoService.java
@@ -219,7 +219,7 @@ abstract class GenericDefectDojoService<T extends Model> implements DefectDojoSe
     }
 
     var url = new URI(this.config.getUrl() + API_PREFIX + this.getUrlPath() + "/");
-    log.debug("Requesting URL: " + url);
+    log.debug("Requesting URL: {}", url);
     var uriBuilder = UriComponentsBuilder.fromUri(url).queryParams(multiValueMap);
 
     ResponseEntity<String> responseString = restTemplate.exchange(

--- a/src/main/java/io/securecodebox/persistence/defectdojo/service/ImportScanService2.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/service/ImportScanService2.java
@@ -22,7 +22,7 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
@@ -94,8 +94,8 @@ public class ImportScanService2 {
       var payload = new HttpEntity<>(mvn, headers);
 
       return restTemplate.exchange(config.getUrl() + "/api/v2/" + endpoint + "/", HttpMethod.POST, payload, ImportScanResponse.class).getBody();
-    } catch (HttpClientErrorException e) {
-      throw new PersistenceException("Failed to attach findings to engagement.");
+    } catch (RestClientException e) {
+      throw new PersistenceException("Failed to attach findings to engagement.", e);
     }
   }
 


### PR DESCRIPTION
Two Problems:
1. We do not pass consequently the causing exception to our own custom exception.
2. We do not catch all possible REST client runtime exceptions.

Fixed by consequent logging and passing ofthe origin exception as cause of our own excpetion. Also catching a more generic exception type totach all possible errors.