### PR TITLE
Revert "#23 Use native types as model's field types"

### DIFF
--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Endpoint.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Endpoint.java
@@ -17,8 +17,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Endpoint implements Model, HasId {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   private String protocol;
@@ -30,7 +39,7 @@ public final class Endpoint implements Model, HasId {
   private String fullyQualifiedDomainName;
 
   @JsonProperty
-  private long port;
+  private Long port;// FIXME: Use native type here.
 
   @JsonProperty
   private String path;
@@ -42,10 +51,10 @@ public final class Endpoint implements Model, HasId {
   private String fragment;
 
   @JsonProperty
-  private long product;
+  private Long product;// FIXME: Use native type here.
 
   @JsonProperty
-  private boolean mitigated;
+  private Boolean mitigated;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Engagement.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Engagement.java
@@ -19,18 +19,27 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Engagement implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
+  @JsonProperty
+  private Long id;
+
+  @JsonProperty
+  private String name;
+
   @JsonProperty("branch_tag")
   @Builder.Default
   private String branch = "";
 
   @JsonProperty
-  private long id;
-
-  @JsonProperty
-  private String name;
-
-  @JsonProperty
-  private long product;
+  private Long product;// FIXME: Use native type here.
 
   @JsonProperty("target_start")
   private String targetStart;
@@ -39,7 +48,7 @@ public final class Engagement implements Model, HasId, HasName {
   private String targetEnd;
 
   @JsonProperty
-  private long lead;
+  private Long lead;// FIXME: Use native type here.
 
   @JsonProperty("engagement_type")
   @Builder.Default
@@ -66,13 +75,13 @@ public final class Engagement implements Model, HasId, HasName {
   private String repo;
 
   @JsonProperty("build_server")
-  private long buildServer;
+  private Long buildServer; // FIXME: Use native type here.
 
   @JsonProperty("source_code_management_server")
-  private long scmServer;
+  private Long scmServer; // FIXME: Use natvive type here.
 
   @JsonProperty("orchestration_engine")
-  private long orchestrationEngine;
+  private Long orchestrationEngine; // FIXME: Use natvive type here.
 
   @JsonProperty
   @Builder.Default
@@ -82,16 +91,20 @@ public final class Engagement implements Model, HasId, HasName {
   private boolean deduplicationOnEngagement;
 
   @JsonProperty("threat_model")
-  private boolean threatModel;
+  @Builder.Default // FIXME: Use native type here.
+  private Boolean threatModel = false;
 
   @JsonProperty("api_test")
-  private boolean apiTest;
+  @Builder.Default // FIXME: Use native type here.
+  private Boolean apiTest = false;
 
   @JsonProperty("pen_test")
-  private boolean penTest;
+  @Builder.Default // FIXME: Use native type here.
+  private Boolean penTest = false;
 
   @JsonProperty("check_list")
-  private boolean checkList;
+  @Builder.Default // FIXME: Use native type here.
+  private Boolean checkList = false;
 
   @JsonProperty
   @Builder.Default

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Finding.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Finding.java
@@ -23,8 +23,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Finding implements Model, HasId {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   @NonNull
@@ -44,7 +53,7 @@ public final class Finding implements Model, HasId {
 
   @JsonProperty
   @NonNull
-  private long test;
+  private Long test;// FIXME: Use native type here.
 
   @JsonProperty
   private String mitigation;
@@ -54,30 +63,37 @@ public final class Finding implements Model, HasId {
 
   @JsonProperty
   @NonNull
-  private boolean active;
+  @Builder.Default
+  private Boolean active = true;// FIXME: Use native type here.
 
   @JsonProperty
   @NonNull
-  private boolean verified;
+  @Builder.Default
+  private Boolean verified = true;// FIXME: Use native type here.
 
   @JsonProperty("risk_accepted")
   @NonNull
-  private boolean riskAccepted;
+  @Builder.Default
+  private Boolean riskAccepted = false;// FIXME: Use native type here.
 
   @JsonProperty("out_of_scope")
   @NonNull
-  private boolean outOfScope;
+  @Builder.Default
+  private Boolean outOfScope = false;// FIXME: Use native type here.
 
   @JsonProperty
   @NonNull
-  private boolean duplicate;
+  @Builder.Default
+  private Boolean duplicate = false;// FIXME: Use native type here.
 
   @JsonProperty("duplicate_finding")
-  private long duplicateFinding;
+  @Builder.Default
+  private Long duplicateFinding = null;// FIXME: Use native type here.
 
   @JsonProperty("false_p")
   @NonNull
-  private boolean falsePositive;
+  @Builder.Default
+  private Boolean falsePositive = false;// FIXME: Use native type here.
 
   @JsonProperty("component_name")
   private String componentName;

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Group.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Group.java
@@ -18,8 +18,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Group implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   @NonNull

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/GroupMember.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/GroupMember.java
@@ -17,17 +17,26 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class GroupMember implements Model {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
-  private long group;
+  private Long group;// FIXME: Use native type here.
 
   @JsonProperty
-  private long user;
+  private Long user;// FIXME: Use native type here.
 
   @JsonProperty
-  private long role;
+  private Long role;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/HasId.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/HasId.java
@@ -12,7 +12,7 @@ package io.securecodebox.persistence.defectdojo.model;
  * </p>
  */
 interface HasId {
-  long getId();
+  Long getId();
 
-  void setId(long id);
+  void setId(Long id);
 }

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Product.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Product.java
@@ -19,8 +19,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Product implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   private String name;
@@ -32,19 +41,19 @@ public final class Product implements Model, HasId, HasName {
   private String description;
 
   @JsonProperty("findings_count")
-  private long findingsCount;
+  private Long findingsCount;// FIXME: Use native type here.
 
   @JsonProperty("authorized_users")
   private List<String> authorizedUsers;
 
   @JsonProperty("prod_type")
-  private long productType;
-
+  private Long productType;// FIXME: Use native type here.
+  
   @JsonProperty("enable_simple_risk_acceptance")
-  private boolean enableSimpleRiskAcceptance;
-
+  private Boolean enableSimpleRiskAcceptance;// FIXME: Use native type here.
+  
   @JsonProperty("enable_full_risk_acceptance")
-  private boolean enableFullRiskAcceptance;
+  private Boolean enableFullRiskAcceptance;// FIXME: Use native type here.
 
   @JsonProperty("authorization_groups")
   @Builder.Default

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/ProductGroup.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/ProductGroup.java
@@ -17,17 +17,26 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ProductGroup implements Model {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
-  private long product;
+  private Long product;// FIXME: Use native type here.
 
   @JsonProperty
-  private long group;
+  private Long group;// FIXME: Use native type here.
 
   @JsonProperty
-  private long role;
+  private Long role;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/ProductType.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/ProductType.java
@@ -18,17 +18,17 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ProductType implements Model, HasId, HasName {
   @JsonProperty
-  private long id;
+  private Long id;// FIXME: Use native type here.
 
   @JsonProperty
   @NonNull
   private String name;
 
   @JsonProperty("critical_product")
-  private boolean criticalProduct;
+  private Boolean criticalProduct;// FIXME: Use native type here.
 
   @JsonProperty("key_product")
-  private boolean keyProduct;
+  private Boolean keyProduct;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/RiskAcceptance.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/RiskAcceptance.java
@@ -18,8 +18,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class RiskAcceptance implements Model, HasId {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   private String recommendation;
@@ -54,7 +63,7 @@ public final class RiskAcceptance implements Model, HasId {
   private OffsetDateTime updatedAt;
 
   @JsonProperty
-  private long owner;
+  private Long owner;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/Test.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/Test.java
@@ -19,8 +19,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class Test implements Model, HasId {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   private String title;
@@ -39,16 +48,16 @@ public final class Test implements Model, HasId {
   private List<String> tags = new LinkedList<>();
 
   @JsonProperty("test_type")
-  private long testType;
+  private Long testType;// FIXME: Use native type here.
 
   @JsonProperty
-  private long lead;
+  private Long lead;// FIXME: Use native type here.
 
   @JsonProperty("percent_complete")
-  private long percentComplete;
+  private Long percentComplete;// FIXME: Use native type here.
 
   @JsonProperty
-  private long engagement;
+  private Long engagement;// FIXME: Use native type here.
 
   @JsonProperty
   private String version;
@@ -59,7 +68,7 @@ public final class Test implements Model, HasId {
    */
   @JsonProperty
   @Builder.Default
-  private long environment = 1L;
+  private Long environment = 1L;// FIXME: Use native type here.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/TestType.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/TestType.java
@@ -17,18 +17,27 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class TestType implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   @NonNull
   private String name;
 
   @JsonProperty("static_tool")
-  private boolean staticTool;
+  private Boolean staticTool;// FIXME: Use native type here.
 
   @JsonProperty("dynamic_tool")
-  private boolean dynamicTool;
+  private Boolean dynamicTool;// FIXME: Use native type here.
 
 
   @Override

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/ToolConfig.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/ToolConfig.java
@@ -17,25 +17,34 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ToolConfig implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
-  String url;
+  String url; // FIXME: Make private.
 
   @JsonProperty
   @NonNull
-  String name;
+  String name; // FIXME: Make private.
 
   @JsonProperty("tool_type")
-  private long toolType;
+  private Long toolType;// FIXME: Use native type here.
 
   // FIXME: This is not present in my actual JSON response. Should remove?
   @JsonProperty("configuration_url")
   String configUrl;
 
   @JsonProperty
-  String description;
+  String description;// FIXME: Make private.
 
   @Override
   public boolean equalsQueryString(Map<String, Object> queryParams) {

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/ToolType.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/ToolType.java
@@ -17,8 +17,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class ToolType implements Model, HasId, HasName {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   @NonNull

--- a/src/main/java/io/securecodebox/persistence/defectdojo/model/User.java
+++ b/src/main/java/io/securecodebox/persistence/defectdojo/model/User.java
@@ -17,8 +17,17 @@ import java.util.Map;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public final class User implements Model, HasId {
+  /**
+   * Uniq id of model type
+   * <p>
+   * May be {@code null} for newly created objects because in DefectDojo's Open API specification i.
+   * It is mandatory to use a boxed object type instead of a native type. A native type would result in 0 by
+   * default which is a valid id for DefectDojo. Thus creating this type via POST request would try to create
+   * one with id 0. Instead the id must be {@code null}, so that DefectDojo uses a newly generated uniq id.
+   * </p>
+   */
   @JsonProperty
-  private long id;
+  private Long id;
 
   @JsonProperty
   @NonNull

--- a/src/test/java/io/securecodebox/persistence/defectdojo/model/FindingTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/model/FindingTest.java
@@ -28,6 +28,7 @@ class FindingTest {
       .description("description")
       .foundBy(Collections.emptyList())
       .severity(Finding.Severity.INFORMATIONAL)
+      .test(0L)
       .build();
     assertThat(sut.equalsQueryString(null), is(false));
 

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/EndpointServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/EndpointServiceTest.java
@@ -25,39 +25,39 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
   private final EndpointService sut = new EndpointService(conf());
   private final Endpoint[] expectedFromSearch = new Endpoint[]{
     Endpoint.builder()
-      .id(956)
+      .id(956L)
       .protocol("tcp")
       .host("10.0.0.1")
-      .port(80)
-      .product(320)
+      .port(80L)
+      .product(320L)
       .build(),
     Endpoint.builder()
-      .id(957)
+      .id(957L)
       .protocol("tcp")
       .host("10.0.0.1")
-      .port(443)
-      .product(320)
+      .port(443L)
+      .product(320L)
       .build(),
     Endpoint.builder()
-      .id(961)
+      .id(961L)
       .protocol("tcp")
       .host("10.0.0.2")
-      .port(80)
-      .product(323)
+      .port(80L)
+      .product(323L)
       .build(),
     Endpoint.builder()
-      .id(962)
+      .id(962L)
       .protocol("tcp")
       .host("10.0.0.2")
-      .port(443)
-      .product(323)
+      .port(443L)
+      .product(323L)
       .build(),
     Endpoint.builder()
-      .id(893)
+      .id(893L)
       .protocol("tcp")
       .host("10.0.0.3")
-      .port(443)
-      .product(296)
+      .port(443L)
+      .product(296L)
       .build()};
 
   @Test
@@ -133,11 +133,11 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Endpoint.builder()
-      .id(42)
+      .id(42L)
       .protocol("tcp")
       .host("www.owasp.org")
-      .port(443)
-      .product(285)
+      .port(443L)
+      .product(285L)
       .build();
 
     final var result = sut.get(42L);
@@ -155,16 +155,13 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("id", equalTo("42"))
       .withQueryParam("product", equalTo("285"))
-      // Defaults from model:
-      .withQueryParam("port", equalTo("0"))
-      .withQueryParam("mitigated", equalTo("false"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
       ));
     final var searchObject = Endpoint.builder()
-      .id(42)
-      .product(285)
+      .id(42L)
+      .product(285L)
       .build();
 
     final var result = sut.searchUnique(searchObject);
@@ -202,8 +199,7 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
         "protocol": "tcp",
         "host": "www.owasp.org",
         "port":443,
-        "product": 285,
-        "mitigated": false
+        "product": 285
       }
       """;
     stubFor(post(urlPathEqualTo("/api/v2/endpoints/"))
@@ -213,11 +209,11 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = Endpoint.builder()
-      .id(42)
+      .id(42L)
       .protocol("tcp")
       .host("www.owasp.org")
-      .port(443)
-      .product(285)
+      .port(443L)
+      .product(285L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -243,8 +239,7 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
         "protocol": "tcp",
         "host": "www.owasp.org",
         "port": 443,
-        "product":285,
-        "mitigated": false
+        "product":285
       }
       """;
     stubFor(put(urlPathEqualTo("/api/v2/endpoints/42/"))
@@ -255,11 +250,11 @@ final class EndpointServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = Endpoint.builder()
-      .id(42)
+      .id(42L)
       .protocol("tcp")
       .host("www.owasp.org")
-      .port(443)
-      .product(285)
+      .port(443L)
+      .product(285L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/EngagementServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/EngagementServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.Engagement;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,7 +25,7 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "EngagementService_response_list_fixture.json";
   private final EngagementService sut = new EngagementService(conf());
   private final Engagement[] expectedFromSearch = {Engagement.builder()
-    .id(806)
+    .id(806L)
     .branch("")
     .name("nmap-vienna-client-1709886900")
     .description("")
@@ -35,13 +34,13 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
     .targetEnd("2024-03-08")
     .status(Engagement.Status.IN_PROGRESS)
     .engagementType("CI/CD")
-    .lead(3)
-    .product(162)
-    .orchestrationEngine(1)
+    .lead(3L)
+    .product(162L)
+    .orchestrationEngine(1L)
     .tags(Collections.emptyList())
     .build(),
     Engagement.builder()
-      .id(807)
+      .id(807L)
       .branch("")
       .name("nmap-stuttgart-client-1709886900")
       .description("")
@@ -50,13 +49,13 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       .targetEnd("2024-03-08")
       .status(Engagement.Status.IN_PROGRESS)
       .engagementType("CI/CD")
-      .lead(3)
-      .product(139)
-      .orchestrationEngine(1)
+      .lead(3L)
+      .product(139L)
+      .orchestrationEngine(1L)
       .tags(Collections.emptyList())
       .build(),
     Engagement.builder()
-      .id(808)
+      .id(808L)
       .branch("")
       .name("nmap-frankfurt-client-1709886900")
       .description("")
@@ -65,9 +64,9 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       .targetEnd("2024-03-08")
       .status(Engagement.Status.IN_PROGRESS)
       .engagementType("CI/CD")
-      .lead(3)
-      .product(140)
-      .orchestrationEngine(1)
+      .lead(3L)
+      .product(140L)
+      .orchestrationEngine(1L)
       .tags(Collections.emptyList())
       .build()};
 
@@ -166,13 +165,13 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Engagement.builder()
-      .id(42)
+      .id(42L)
       .name("nmap-office-client-1710146100")
-      .product(139)
+      .product(139L)
       .targetStart("2024-03-11")
       .targetEnd("2024-03-11")
-      .lead(3)
-      .orchestrationEngine(1)
+      .lead(3L)
+      .orchestrationEngine(1L)
       .build();
 
     final var result = sut.get(42L);
@@ -191,16 +190,10 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       .withQueryParam("version", equalTo("foo"))
       .withQueryParam("name", equalTo("bar"))
       // Defaults from model:
-      .withQueryParam("product", equalTo("0"))
       .withQueryParam("check_list", equalTo("false"))
       .withQueryParam("pen_test", equalTo("false"))
-      .withQueryParam("source_code_management_server", equalTo("0"))
-      .withQueryParam("lead", equalTo("0"))
-      .withQueryParam("orchestration_engine", equalTo("0"))
       .withQueryParam("threat_model", equalTo("false"))
       .withQueryParam("engagement_type", equalTo("CI/CD"))
-      .withQueryParam("build_server", equalTo("0"))
-      .withQueryParam("id", equalTo("0"))
       .withQueryParam("deduplication_on_engagement", equalTo("false"))
       .withQueryParam("api_test", equalTo("false"))
       .withQueryParam("status", equalTo("In Progress"))
@@ -257,8 +250,6 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
          "target_start" : "2024-03-11",
          "target_end" : "2024-03-11",
          "engagement_type" : "CI/CD",
-         "build_server" : 0,
-         "source_code_management_server" : 0,
          "orchestration_engine" : 1,
          "deduplication_on_engagement" : false,
          "threat_model" : true,
@@ -274,7 +265,7 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = Engagement.builder()
-      .id(42)
+      .id(42L)
       .name("nmap-office-client-1710146100")
       .description("SNAFU")
       .targetStart("2024-03-11")
@@ -282,9 +273,9 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       .status(Engagement.Status.IN_PROGRESS)
       .threatModel(true)
       .engagementType("CI/CD")
-      .lead(3)
-      .product(139)
-      .orchestrationEngine(1)
+      .lead(3L)
+      .product(139L)
+      .orchestrationEngine(1L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -318,8 +309,6 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
         "target_start" : "2024-03-11",
         "target_end" : "2024-03-11",
         "engagement_type" : "CI/CD",
-        "build_server" : 0,
-        "source_code_management_server" : 0,
         "orchestration_engine" : 1,
         "deduplication_on_engagement" : false,
         "threat_model" : true,
@@ -336,7 +325,7 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = Engagement.builder()
-      .id(42)
+      .id(42L)
       .name("nmap-office-client-1710146100")
       .description("SNAFU")
       .targetStart("2024-03-11")
@@ -344,9 +333,9 @@ final class EngagementServiceTest extends WireMockBaseTestCase {
       .status(Engagement.Status.IN_PROGRESS)
       .threatModel(true)
       .engagementType("CI/CD")
-      .lead(3)
-      .product(139)
-      .orchestrationEngine(1)
+      .lead(3L)
+      .product(139L)
+      .orchestrationEngine(1L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/FindingServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/FindingServiceTest.java
@@ -4,13 +4,8 @@
 
 package io.securecodebox.persistence.defectdojo.service;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.Finding;
-import io.securecodebox.persistence.defectdojo.model.RiskAcceptance;
-import lombok.Builder;
-import lombok.NonNull;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -18,7 +13,6 @@ import java.net.URISyntaxException;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -35,12 +29,12 @@ final class FindingServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_SINGLE_FIXTURE_JSON = "FindingService_response_single_fixture.json";
   private final FindingService sut = new FindingService(conf());
   private final Finding expectedFromSearch = Finding.builder()
-    .id(42)
+    .id(42L)
     .title("Open Port: 9929/TCP")
     .description("IP Address: 198.51.100.0 FQDN: scanme.nmap.org Port/Protocol: 9929/tcp")
     .foundBy(List.of(132L))
     .severity(Finding.Severity.INFORMATIONAL)
-    .test(222)
+    .test(222L)
     .mitigation("N/A")
     .impact("No impact provided")
     .verified(true)
@@ -109,15 +103,16 @@ final class FindingServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Finding.builder()
-      .id(42)
+      .id(42L)
       .title("www.owasp.org")
       .description("Found subdomain www.owasp.org")
       .severity(Finding.Severity.INFORMATIONAL)
       .foundBy(List.of(128L))
-      .test(17)
+      .test(17L)
       .active(true)
       .endpoints(List.of(5L))
       .createdAt(OffsetDateTime.parse("2024-03-02T08:28:00.407414Z"))
+      .verified(false)
       .build();
 
     final var result = sut.get(42L);
@@ -139,14 +134,12 @@ final class FindingServiceTest extends WireMockBaseTestCase {
       .withQueryParam("severity", equalTo("High"))
       // Defaults from model:
       .withQueryParam("endpoints", equalTo("[]"))
-      .withQueryParam("test", equalTo("0"))
-      .withQueryParam("verified", equalTo("false"))
-      .withQueryParam("active", equalTo("false"))
+      .withQueryParam("test", equalTo("23"))
+      .withQueryParam("verified", equalTo("true"))
+      .withQueryParam("active", equalTo("true"))
       .withQueryParam("duplicate", equalTo("false"))
       .withQueryParam("out_of_scope", equalTo("false"))
       .withQueryParam("risk_accepted", equalTo("false"))
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("duplicate_finding", equalTo("0"))
       .withQueryParam("numerical_severity", equalTo("S1"))
       .withQueryParam("false_p", equalTo("false"))
       .willReturn(ok()
@@ -159,6 +152,7 @@ final class FindingServiceTest extends WireMockBaseTestCase {
       .description("snafu")
       .foundBy(List.of(12L, 42L))
       .severity(Finding.Severity.HIGH)
+      .test(23L)
       .build();
 
     final var result = sut.searchUnique(searchObject);
@@ -193,19 +187,17 @@ final class FindingServiceTest extends WireMockBaseTestCase {
   void create() {
     final var json = """
       {
-        "id" : 0,
         "title" : "foo",
         "description" : "bar",
         "severity" : "High",
-        "test" : 0,
-        "active" : false,
-        "verified" : false,
+        "test" : 42,
+        "active" : true,
+        "verified" : true,
         "duplicate" : false,
         "endpoints" : [ ],
         "found_by" : [ 1, 2, 3 ],
         "risk_accepted" : false,
         "out_of_scope" : false,
-        "duplicate_finding" : 0,
         "false_p" : false,
         "accepted_risks" : [ ],
         "numerical_severity" : "S1"
@@ -222,6 +214,7 @@ final class FindingServiceTest extends WireMockBaseTestCase {
       .description("bar")
       .foundBy(List.of(1L, 2L, 3L))
       .severity(Finding.Severity.HIGH)
+      .test(42L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -243,19 +236,17 @@ final class FindingServiceTest extends WireMockBaseTestCase {
   void update() {
     final var json = """
       {
-        "id" : 0,
         "title" : "foo",
         "description" : "bar",
         "severity" : "High",
-        "test" : 0,
-        "active" : false,
-        "verified" : false,
+        "test" : 42,
+        "active" : true,
+        "verified" : true,
         "duplicate" : false,
         "endpoints" : [ ],
         "found_by" : [ 1, 2, 3 ],
         "risk_accepted" : false,
         "out_of_scope" : false,
-        "duplicate_finding" : 0,
         "false_p" : false,
         "accepted_risks" : [ ],
         "numerical_severity" : "S1"
@@ -273,6 +264,7 @@ final class FindingServiceTest extends WireMockBaseTestCase {
       .description("bar")
       .foundBy(List.of(1L, 2L, 3L))
       .severity(Finding.Severity.HIGH)
+      .test(42L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/GroupMemberServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/GroupMemberServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.GroupMember;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,46 +24,46 @@ final class GroupMemberServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "GroupMemberService_response_list_fixture.json";
   private final GroupMemberService sut = new GroupMemberService(conf());
   private final GroupMember[] expectedFromSearch = {GroupMember.builder()
-    .id(10)
-    .group(10)
-    .user(4)
-    .role(3)
+    .id(10L)
+    .group(10L)
+    .user(4L)
+    .role(3L)
     .build(),
     GroupMember.builder()
-      .id(1)
-      .group(1)
-      .user(2)
-      .role(3)
+      .id(1L)
+      .group(1L)
+      .user(2L)
+      .role(3L)
       .build(),
     GroupMember.builder()
-      .id(9)
-      .group(9)
-      .user(4)
-      .role(3)
+      .id(9L)
+      .group(9L)
+      .user(4L)
+      .role(3L)
       .build(),
     GroupMember.builder()
-      .id(4)
-      .group(4)
-      .user(4)
-      .role(3)
+      .id(4L)
+      .group(4L)
+      .user(4L)
+      .role(3L)
       .build(),
     GroupMember.builder()
-      .id(12)
-      .group(1)
-      .user(4)
-      .role(3)
+      .id(12L)
+      .group(1L)
+      .user(4L)
+      .role(3L)
       .build(),
     GroupMember.builder()
-      .id(6)
-      .group(6)
-      .user(4)
-      .role(3)
+      .id(6L)
+      .group(6L)
+      .user(4L)
+      .role(3L)
       .build(),
     GroupMember.builder()
-      .id(14)
-      .group(1)
-      .user(5)
-      .role(3)
+      .id(14L)
+      .group(1L)
+      .user(5L)
+      .role(3L)
       .build()};
 
   @Test
@@ -127,10 +126,10 @@ final class GroupMemberServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = GroupMember.builder()
-      .id(42)
-      .group(1)
-      .user(5)
-      .role(3)
+      .id(42L)
+      .group(1L)
+      .user(5L)
+      .role(3L)
       .build();
 
     final var result = sut.get(42L);
@@ -148,17 +147,14 @@ final class GroupMemberServiceTest extends WireMockBaseTestCase {
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("group", equalTo("23"))
       .withQueryParam("user", equalTo("42"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("role", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
       ));
 
     final var searchObject = GroupMember.builder()
-      .group(23)
-      .user(42)
+      .group(23L)
+      .user(42L)
       .build();
 
     final var result = sut.searchUnique(searchObject);
@@ -206,10 +202,10 @@ final class GroupMemberServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = GroupMember.builder()
-      .id(42)
-      .user(23)
-      .role(1)
-      .group(2)
+      .id(42L)
+      .user(23L)
+      .role(1L)
+      .group(2L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -245,10 +241,10 @@ final class GroupMemberServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = GroupMember.builder()
-      .id(42)
-      .user(23)
-      .role(1)
-      .group(2)
+      .id(42L)
+      .user(23L)
+      .role(1L)
+      .group(2L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/GroupServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/GroupServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.Group;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -26,19 +25,19 @@ final class GroupServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "GroupService_response_list_fixture.json";
   private final GroupService sut = new GroupService(conf());
   private final Group[] expectedFromSearch = {Group.builder()
-    .id(1)
+    .id(1L)
     .name("foo")
     .socialProvider("GitHub")
     .users(List.of(4L))
     .build(),
     Group.builder()
-      .id(2)
+      .id(2L)
       .name("bar")
       .socialProvider("GitHub")
       .users(List.of(1L, 2L, 3L))
       .build(),
     Group.builder()
-      .id(3)
+      .id(3L)
       .name("snafu")
       .socialProvider("GitHub")
       .users(List.of(4L, 5L))
@@ -110,7 +109,7 @@ final class GroupServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Group.builder()
-      .id(9)
+      .id(9L)
       .name("team-orange")
       .socialProvider("GitHub")
       .users(List.of(4L, 5L, 6L))
@@ -130,8 +129,6 @@ final class GroupServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -187,7 +184,7 @@ final class GroupServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = Group.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
       .socialProvider("GitHub")
@@ -228,7 +225,7 @@ final class GroupServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = Group.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
       .socialProvider("GitHub")

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductGroupServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductGroupServiceTest.java
@@ -25,22 +25,22 @@ final class ProductGroupServiceTest extends WireMockBaseTestCase {
   private final ProductGroupService sut = new ProductGroupService(conf());
   private final ProductGroup[] expectedFromSearch = new ProductGroup[]{
     ProductGroup.builder()
-      .id(1)
-      .product(2)
-      .group(3)
-      .role(4)
+      .id(1L)
+      .product(2L)
+      .group(3L)
+      .role(4L)
       .build(),
     ProductGroup.builder()
-      .id(5)
-      .product(6)
-      .group(7)
-      .role(8)
+      .id(5L)
+      .product(6L)
+      .group(7L)
+      .role(8L)
       .build(),
     ProductGroup.builder()
-      .id(9)
-      .product(10)
-      .group(11)
-      .role(12)
+      .id(9L)
+      .product(10L)
+      .group(11L)
+      .role(12L)
       .build()
   };
 
@@ -103,10 +103,10 @@ final class ProductGroupServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = ProductGroup.builder()
-      .id(42)
-      .product(2)
-      .group(3)
-      .role(4)
+      .id(42L)
+      .product(2L)
+      .group(3L)
+      .role(4L)
       .build();
 
     final var result = sut.get(42L);
@@ -123,17 +123,13 @@ final class ProductGroupServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("product", equalTo("42"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("role", equalTo("0"))
-      .withQueryParam("group", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
       ));
 
     final var searchObject = ProductGroup.builder()
-      .product(42)
+      .product(42L)
       .build();
 
     final var result = sut.searchUnique(searchObject);
@@ -181,10 +177,10 @@ final class ProductGroupServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = ProductGroup.builder()
-      .id(42)
-      .product(285)
-      .group(23)
-      .role(47)
+      .id(42L)
+      .product(285L)
+      .group(23L)
+      .role(47L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -220,10 +216,10 @@ final class ProductGroupServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = ProductGroup.builder()
-      .id(42)
-      .product(285)
-      .group(23)
-      .role(47)
+      .id(42L)
+      .product(285L)
+      .group(23L)
+      .role(47L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.Product;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -27,7 +26,7 @@ final class ProductServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "ProductService_response_list_fixture.json";
   private final ProductService sut = new ProductService(conf());
   private final Product[] expectedFromSearch = {Product.builder()
-    .id(419)
+    .id(419L)
     .name("10.0.0.1")
     .description("Product was automatically created by the secureCodeBox DefectDojo integration")
     .tags(List.of(
@@ -36,13 +35,14 @@ final class ProductServiceTest extends WireMockBaseTestCase {
       "org/owasp",
       "vlan/dev"
     ))
-    .productType(2)
-    .findingsCount(12)
+    .productType(2L)
+    .findingsCount(12L)
     .enableFullRiskAcceptance(true)
     .authorizationGroups(Collections.emptyList())
+    .enableSimpleRiskAcceptance(false)
     .build(),
     Product.builder()
-      .id(312)
+      .id(312L)
       .name("10.0.0.2")
       .description("Product was automatically created by the secureCodeBox DefectDojo integration")
       .tags(List.of(
@@ -51,13 +51,14 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         "org/owasp",
         "vlan/dev"
       ))
-      .productType(1)
-      .findingsCount(16)
+      .productType(1L)
+      .findingsCount(16L)
       .enableFullRiskAcceptance(false)
       .authorizationGroups(List.of(1L, 2L, 3L))
+      .enableSimpleRiskAcceptance(false)
       .build(),
     Product.builder()
-      .id(297)
+      .id(297L)
       .name("10.0.0.3")
       .description("Product was automatically created by the secureCodeBox DefectDojo integration")
       .tags(List.of(
@@ -65,10 +66,11 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         "office/munich",
         "org/owasp"
       ))
-      .productType(2)
-      .findingsCount(16)
+      .productType(2L)
+      .findingsCount(16L)
       .enableSimpleRiskAcceptance(true)
       .authorizationGroups(Collections.emptyList())
+      .enableFullRiskAcceptance(false)
       .build()};
 
   @Test
@@ -162,23 +164,23 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Product.builder()
-      .id(320)
+      .id(320L)
       .name("10.0.0.1")
       .description("Product was automatically created by the secureCodeBox DefectDojo integration")
       .tags(List.of(
         "attack-surface/internal",
         "org/owasp"
       ))
-      .findingsCount(2)
-      .productType(2)
+      .findingsCount(2L)
+      .productType(2L)
       .enableFullRiskAcceptance(true)
+      .enableSimpleRiskAcceptance(false)
       .build();
 
     final var result = sut.get(320);
 
     assertThat(result, is(expected));
   }
-
 
   @Test
   void searchUnique_withSearchObject() throws URISyntaxException, JsonProcessingException {
@@ -188,12 +190,6 @@ final class ProductServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("prod_type", equalTo("0"))
-      .withQueryParam("enable_simple_risk_acceptance", equalTo("false"))
-      .withQueryParam("enable_full_risk_acceptance", equalTo("false"))
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("findings_count", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -239,10 +235,7 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         "name" : "foo",
         "tags" : [ "foo", "bar", "baz" ],
         "description" : "bar",
-        "findings_count" : 0,
         "prod_type" : 23,
-        "enable_simple_risk_acceptance" : false,
-        "enable_full_risk_acceptance" : false,
         "authorization_groups" : [ ]
       }
       """;
@@ -253,10 +246,10 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = Product.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
-      .productType(23)
+      .productType(23L)
       .tags(List.of("foo", "bar", "baz"))
       .build();
 
@@ -283,10 +276,7 @@ final class ProductServiceTest extends WireMockBaseTestCase {
         "name" : "foo",
         "tags" : [ "foo", "bar", "baz" ],
         "description" : "bar",
-        "findings_count" : 0,
         "prod_type" : 23,
-        "enable_simple_risk_acceptance" : false,
-        "enable_full_risk_acceptance" : false,
         "authorization_groups" : [ ]
       }
       """;
@@ -298,10 +288,10 @@ final class ProductServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = Product.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
-      .productType(23)
+      .productType(23L)
       .tags(List.of("foo", "bar", "baz"))
       .build();
 

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductTypeServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/ProductTypeServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.ProductType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,13 +24,13 @@ final class ProductTypeServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "ProductTypeService_response_list_fixture.json";
   private final ProductTypeService sut = new ProductTypeService(conf());
   private final ProductType[] expectedFromSearch = {ProductType.builder()
-    .id(1)
+    .id(1L)
     .name("Research and Development")
     .criticalProduct(true)
     .keyProduct(false)
     .build(),
     ProductType.builder()
-      .id(2)
+      .id(2L)
       .name("secureCodeBox")
       .criticalProduct(false)
       .keyProduct(false)
@@ -105,9 +104,10 @@ final class ProductTypeServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = ProductType.builder()
-      .id(1)
+      .id(1L)
       .name("Research and Development")
       .criticalProduct(true)
+      .keyProduct(false)
       .build();
 
     final var result = sut.get(1);
@@ -124,10 +124,6 @@ final class ProductTypeServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("key_product", equalTo("false"))
-      .withQueryParam("critical_product", equalTo("false"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -182,7 +178,7 @@ final class ProductTypeServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = ProductType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .criticalProduct(true)
       .keyProduct(true)
@@ -221,7 +217,7 @@ final class ProductTypeServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = ProductType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .criticalProduct(true)
       .keyProduct(true)

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/TestServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/TestServiceTest.java
@@ -7,7 +7,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.Test;
-import org.junit.jupiter.api.Disabled;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,40 +25,40 @@ final class TestServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "TestService_response_list_fixture.json";
   private final TestService sut = new TestService(conf());
   private final Test[] expectedFromSearch = {Test.builder()
-    .id(1)
+    .id(1L)
     .title("nuclei-owasp.org-1709280838-nmap-hostscan-6ckh4-nmap-su466fl")
     .description("# Nuclei Scan\nStarted: 01.03.2024 10:04:54\nEnded: 01.03.2024 15:06:30\nScanType: nuclei\nParameters: [-disable-update-check,-no-interactsh,-u,api.tokengate.dlt.owasp.org:443]")
     .targetStart("2024-03-01T10:04:54Z")
     .targetEnd("2024-03-01T15:06:29Z")
-    .testType(67)
-    .lead(3)
-    .percentComplete(100)
-    .engagement(1)
-    .environment(1)
+    .testType(67L)
+    .lead(3L)
+    .percentComplete(100L)
+    .engagement(1L)
+    .environment(1L)
     .build(),
     Test.builder()
-      .id(2)
+      .id(2L)
       .title("nuclei-owasp.org-1709280838-nmap-hostscan-7xd2c-nuclei-5gzps")
       .description("# Nuclei Scan\nStarted: 01.03.2024 08:47:33\nEnded: 01.03.2024 15:06:34\nScanType: nuclei\nParameters: [-disable-update-check,-no-interactsh,-u,api.tokengate-dev.dlt.owasp.org]")
       .targetStart("2024-03-01T08:47:33Z")
       .targetEnd("2024-03-01T15:06:34Z")
-      .testType(42)
-      .lead(23)
-      .percentComplete(43)
-      .engagement(2)
-      .environment(3)
+      .testType(42L)
+      .lead(23L)
+      .percentComplete(43L)
+      .engagement(2L)
+      .environment(3L)
       .build(),
     Test.builder()
-      .id(3)
+      .id(3L)
       .title("nuclei-owasp.org-1709280838-nmap-hostscan-6ckh4-nmap-sub6l7l")
       .description("# Nuclei Scan\nStarted: 01.03.2024 10:04:54\nEnded: 01.03.2024 15:06:35\nScanType: nuclei\nParameters: [-disable-update-check,-no-interactsh,-u,api.tokengate.dlt.owasp.org]")
       .targetStart("2024-03-01T10:04:54Z")
       .targetEnd("2024-03-01T15:06:35Z")
-      .testType(67)
-      .lead(3)
-      .percentComplete(100)
-      .engagement(1)
-      .environment(1)
+      .testType(67L)
+      .lead(3L)
+      .percentComplete(100L)
+      .engagement(1L)
+      .environment(1L)
       .build()};
 
   @org.junit.jupiter.api.Test
@@ -143,15 +142,15 @@ final class TestServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = Test.builder()
-      .id(200)
+      .id(200L)
       .title("nmap-owasp.org-1709367238-nmap-hostscan-tlswv")
       .description("# Nmap Scan...")
       .targetStart("2024-03-02T08:27:58Z")
       .targetEnd("2024-03-02T08:45:05Z")
-      .testType(113)
-      .lead(3)
-      .percentComplete(100)
-      .engagement(64)
+      .testType(113L)
+      .lead(3L)
+      .percentComplete(100L)
+      .engagement(64L)
       .build();
 
     final var result = sut.get(200);
@@ -170,11 +169,6 @@ final class TestServiceTest extends WireMockBaseTestCase {
       .withQueryParam("title", equalTo("foo"))
       // Defaults from model:
       .withQueryParam("environment", equalTo("1"))
-      .withQueryParam("engagement", equalTo("0"))
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("lead", equalTo("0"))
-      .withQueryParam("test_type", equalTo("0"))
-      .withQueryParam("percent_complete", equalTo("0"))
       .withQueryParam("tags", equalTo("[]"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
@@ -221,7 +215,6 @@ final class TestServiceTest extends WireMockBaseTestCase {
         "title" : "foo",
         "description" : "bar",
         "tags" : [ ],
-        "lead" : 0,
         "engagement" : 23,
         "environment" : 1,
         "target_start" : "start",
@@ -237,14 +230,14 @@ final class TestServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = Test.builder()
-      .id(42)
+      .id(42L)
       .title("foo")
       .description("bar")
-      .engagement(23)
+      .engagement(23L)
       .targetStart("start")
       .targetEnd("end")
-      .percentComplete(100)
-      .testType(5)
+      .percentComplete(100L)
+      .testType(5L)
       .build();
 
     final var result = sut.create(toCreate);
@@ -270,7 +263,6 @@ final class TestServiceTest extends WireMockBaseTestCase {
         "title" : "foo",
         "description" : "bar",
         "tags" : [ ],
-        "lead" : 0,
         "engagement" : 23,
         "environment" : 1,
         "target_start" : "start",
@@ -287,14 +279,14 @@ final class TestServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = Test.builder()
-      .id(42)
+      .id(42L)
       .title("foo")
       .description("bar")
-      .engagement(23)
+      .engagement(23L)
       .targetStart("start")
       .targetEnd("end")
-      .percentComplete(100)
-      .testType(5)
+      .percentComplete(100L)
+      .testType(5L)
       .build();
 
     final var result = sut.update(toUpdate, 42L);

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/TestTypeServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/TestTypeServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.TestType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,55 +24,55 @@ final class TestTypeServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "TestTypeService_response_list_fixture.json";
   private final TestTypeService sut = new TestTypeService(conf());
   private final TestType[] expectedFromSearch = {TestType.builder()
-    .id(99)
+    .id(99L)
     .name("Acunetix360 Scan")
     .staticTool(false)
     .dynamicTool(false)
     .build(),
     TestType.builder()
-      .id(19)
+      .id(19L)
       .name("Acunetix Scan")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(125)
+      .id(125L)
       .name("AnchoreCTL Policies Report")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(47)
+      .id(47L)
       .name("AnchoreCTL Vuln Report")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(112)
+      .id(112L)
       .name("Anchore Engine Scan")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(172)
+      .id(172L)
       .name("Anchore Enterprise Policy Check")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(106)
+      .id(106L)
       .name("Anchore Grype")
       .staticTool(true)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(1)
+      .id(1L)
       .name("API Test")
       .staticTool(false)
       .dynamicTool(false)
       .build(),
     TestType.builder()
-      .id(100)
+      .id(100L)
       .name("AppSpider Scan")
       .staticTool(false)
       .dynamicTool(true)
@@ -139,7 +138,7 @@ final class TestTypeServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = TestType.builder()
-      .id(42)
+      .id(42L)
       .name("SNAFU Scan")
       .dynamicTool(true)
       .staticTool(true)
@@ -159,10 +158,6 @@ final class TestTypeServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("static_tool", equalTo("false"))
-      .withQueryParam("dynamic_tool", equalTo("false"))
-      .withQueryParam("id", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -217,7 +212,7 @@ final class TestTypeServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = TestType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .staticTool(true)
       .dynamicTool(true)
@@ -256,7 +251,7 @@ final class TestTypeServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = TestType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .staticTool(true)
       .dynamicTool(true)

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/ToolConfigServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/ToolConfigServiceTest.java
@@ -25,11 +25,11 @@ final class ToolConfigServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "ToolConfigService_response_list_fixture.json";
   private final ToolConfigService sut = new ToolConfigService(conf());
   private final ToolConfig expectedFromSearch = ToolConfig.builder()
-    .id(1)
+    .id(1L)
     .name("secureCodeBox")
     .description("secureCodeBox is a kubernetes based, modularized toolchain for continuous security scans of your software project.")
     .url("https://github.com/secureCodeBox")
-    .toolType(7)
+    .toolType(7L)
     .build();
 
   @Test
@@ -97,11 +97,11 @@ final class ToolConfigServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = ToolConfig.builder()
-      .id(1)
+      .id(1L)
       .name("secureCodeBox")
       .description("secureCodeBox is a kubernetes based, modularized toolchain for continuous security scans of your software project.")
       .url("https://github.com/secureCodeBox")
-      .toolType(7)
+      .toolType(7L)
       .build();
 
     final var result = sut.get(1);
@@ -118,9 +118,6 @@ final class ToolConfigServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
-      .withQueryParam("tool_type", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -176,8 +173,8 @@ final class ToolConfigServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = ToolConfig.builder()
-      .id(42)
-      .toolType(23)
+      .id(42L)
+      .toolType(23L)
       .name("foo")
       .description("bar")
       .configUrl("snafu")
@@ -217,8 +214,8 @@ final class ToolConfigServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = ToolConfig.builder()
-      .id(42)
-      .toolType(23)
+      .id(42L)
+      .toolType(23L)
       .name("foo")
       .description("bar")
       .configUrl("snafu")

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/ToolTypeServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/ToolTypeServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.ToolType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,32 +24,32 @@ final class ToolTypeServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "ToolTypeService_response_list_fixture.json";
   private final ToolTypeService sut = new ToolTypeService(conf());
   private final ToolType[] expectedFromSearch = {ToolType.builder()
-    .id(6)
+    .id(6L)
     .name("BlackDuck API")
     .build(),
     ToolType.builder()
-      .id(3)
+      .id(3L)
       .name("Bugcrowd API")
       .build(),
     ToolType.builder()
-      .id(4)
+      .id(4L)
       .name("Cobalt.io")
       .build(),
     ToolType.builder()
-      .id(1)
+      .id(1L)
       .name("Edgescan")
       .build(),
     ToolType.builder()
-      .id(7)
+      .id(7L)
       .name("Security Test Orchestration Engine")
       .description("Security Test Orchestration Engine")
       .build(),
     ToolType.builder()
-      .id(5)
+      .id(5L)
       .name("SonarQube")
       .build(),
     ToolType.builder()
-      .id(2)
+      .id(2L)
       .name("Vulners")
       .build()};
 
@@ -112,7 +111,7 @@ final class ToolTypeServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = ToolType.builder()
-      .id(7)
+      .id(7L)
       .name("Security Test Orchestration Engine")
       .description("Security Test Orchestration Engine")
       .build();
@@ -131,8 +130,6 @@ final class ToolTypeServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("name", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -186,7 +183,7 @@ final class ToolTypeServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = ToolType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
       .build();
@@ -223,7 +220,7 @@ final class ToolTypeServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = ToolType.builder()
-      .id(42)
+      .id(42L)
       .name("foo")
       .description("bar")
       .build();

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/UserProfileServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/UserProfileServiceTest.java
@@ -101,7 +101,7 @@ final class UserProfileServiceTest extends WireMockBaseTestCase {
       ));
     final var expected = UserProfile.builder()
       .user(User.builder()
-        .id(42)
+        .id(42L)
         .username("alf")
         .firstName("Gordon")
         .lastName("Shumway")
@@ -186,7 +186,7 @@ final class UserProfileServiceTest extends WireMockBaseTestCase {
       ));
     final var toCreate = UserProfile.builder()
       .user(User.builder()
-        .id(42)
+        .id(42L)
         .username("alf")
         .firstName("Gordon")
         .lastName("Shumway")
@@ -229,7 +229,7 @@ final class UserProfileServiceTest extends WireMockBaseTestCase {
 
     final var toUpdate = UserProfile.builder()
       .user(User.builder()
-        .id(42)
+        .id(42L)
         .username("alf")
         .firstName("Gordon")
         .lastName("Shumway")

--- a/src/test/java/io/securecodebox/persistence/defectdojo/service/UserServiceTest.java
+++ b/src/test/java/io/securecodebox/persistence/defectdojo/service/UserServiceTest.java
@@ -5,7 +5,6 @@ package io.securecodebox.persistence.defectdojo.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.securecodebox.persistence.defectdojo.model.User;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,19 +24,19 @@ final class UserServiceTest extends WireMockBaseTestCase {
   private static final String RESPONSE_LIST_FIXTURE_JSON = "UserService_response_list_fixture.json";
   private final UserService sut = new UserService(conf());
   private final User[] expectedFromSearch = {User.builder()
-    .id(1)
+    .id(1L)
     .username("admin")
     .firstName("Admin")
     .lastName("User")
     .build(),
     User.builder()
-      .id(2)
+      .id(2L)
       .username("JannikHollenbach")
       .firstName("Jannik")
       .lastName("Hollenbach")
       .build(),
     User.builder()
-      .id(3)
+      .id(3L)
       .username("SvenStrittmatter")
       .firstName("Sven")
       .lastName("Strittmatter")
@@ -108,7 +107,7 @@ final class UserServiceTest extends WireMockBaseTestCase {
         .withBody(response)
       ));
     final var expected = User.builder()
-      .id(5)
+      .id(5L)
       .username("GordonShumway")
       .firstName("Gordon")
       .lastName("Shumway")
@@ -127,8 +126,6 @@ final class UserServiceTest extends WireMockBaseTestCase {
       .withQueryParam("limit", equalTo("100"))
       .withQueryParam("offset", equalTo("0"))
       .withQueryParam("username", equalTo("foo"))
-      // Defaults from model:
-      .withQueryParam("id", equalTo("0"))
       .willReturn(ok()
         .withHeaders(responseHeaders(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE.length()))
         .withBody(EMPTY_SEARCH_RESULT_RESPONSE_FIXTURE)
@@ -183,7 +180,7 @@ final class UserServiceTest extends WireMockBaseTestCase {
         .withBody(json) // Typically the entity with new assigned id is returned, but we ignore this here.
       ));
     final var toCreate = User.builder()
-      .id(42)
+      .id(42L)
       .username("alf")
       .firstName("Gordon")
       .lastName("Shumway")
@@ -222,7 +219,7 @@ final class UserServiceTest extends WireMockBaseTestCase {
       ));
 
     final var toUpdate = User.builder()
-      .id(42)
+      .id(42L)
       .username("alf")
       .firstName("Gordon")
       .lastName("Shumway")


### PR DESCRIPTION
This reverts commit 49ca35d7d8b5c801553643ef1b69118526bd06ac.

DefectDojo does not expect id properties in POST request, but instead of ignoring them it is required toset them to null.

This is only possible with boxed types.